### PR TITLE
Added support for multiline commit messages

### DIFF
--- a/send.plugin.zsh
+++ b/send.plugin.zsh
@@ -16,11 +16,11 @@ push() {
 
 send() {
   git add "$(git rev-parse --show-toplevel)"
-  if [ $# -eq 1 ]; then
-    git commit -a -m "$1"
-  else
-    git commit -a -m "I'm too lazy to write a commit message."
-  fi
+  case $# in
+    0) git commit -a -m "I'm too lazy to write a commit message.";;
+    1) git commit -a -m "$1";;
+    2) git commit -a -m "$1" -m "$2";;
+  esac
   pull
   push
 }


### PR DESCRIPTION
send now accepts a second argument, which will be passed to `git commit` as the second line(s) of the commit message, translating this

```shell
send 'Commit message' '-added something\n- changed something'
```

to this

```shell
git commit -a -m 'Commit message' -m '-added something\n- changed something'
```