### PR TITLE
Add lock command for committing specific files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ pull from upstream (by default, the remote `origin`) and then push upstream.
 Frequently, developers write out this workflow in full hundreds of times a
 day, so this is a useful time-saving technique.
 
+## Lock
+
+This plugin also provides a `lock` command for committing specific files:
+
+```bash
+lock file1.txt file2.txt 'my commit message'
+```
+
+will get translated to
+
+```bash
+git add file1.txt file2.txt
+git commit -m 'my commit message'
+```
+
+Unlike `send`, which adds everything and pushes, `lock` gives you precise control
+over which files to stage and commit. The commit message should be the last argument.
+
 ## Installation
 
 ### [Antigen](github.com/zsh-users/antigen)

--- a/send.plugin.zsh
+++ b/send.plugin.zsh
@@ -27,7 +27,8 @@ send() {
 
 lock() {
   local msg="${@: -1}"
-  local files=("${@:1:$#-1}")
+  local count=$(($# - 1))
+  local files=("${@:1:$count}")
   git add "${files[@]}"
   git commit -m "$msg"
 }

--- a/send.plugin.zsh
+++ b/send.plugin.zsh
@@ -25,4 +25,9 @@ send() {
   push
 }
 
-
+lock() {
+  local msg="${@: -1}"
+  local files=("${@:1:$#-1}")
+  git add "${files[@]}"
+  git commit -m "$msg"
+}


### PR DESCRIPTION
## Summary
- Add `lock` command that stages and commits specific files with a message
- Document the `lock` command in README.md

## Usage
```bash
lock file1.txt file2.txt 'my commit message'
```

Unlike `send`, which adds everything and pushes, `lock` gives precise control over which files to stage and commit.

## Test plan
- [ ] Verify `lock` command works with multiple files
- [ ] Verify commit message is correctly applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)